### PR TITLE
feat: use callback listener instead of channel receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ticking-timer"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["G07cha"]
 license = "MIT"
@@ -11,3 +11,4 @@ rust-version = "1.65"
 
 [dependencies]
 crossbeam-channel = "0.5.8"
+thiserror = "1.0.40"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,30 +7,39 @@
 //!
 //! ```
 //! use std::time::Duration;
+//! use std::thread;
 //! use ticking_timer::Timer;
 //!
-//! let timer = Timer::new(Duration::from_millis(100));
+//! let timer = Timer::new(Duration::from_millis(100), |remaining| {
+//!   println!("{} milliseconds remaining", remaining.as_millis());
+//! });
+//!
 //! timer.reset(Duration::from_millis(1000));
 //! timer.resume();
-//!
-//! timer.update_receiver.recv().unwrap();
-//! let value = timer.update_receiver.recv().unwrap();
-//! assert!(value.as_millis().le(&900));
 //! ```
-use crossbeam_channel::{bounded, Receiver, SendError, Sender};
+#![warn(clippy::unwrap_used)]
+
+use crossbeam_channel::{bounded, SendError, Sender};
 use std::{
-  sync::{Arc, Condvar, Mutex},
+  sync::{Arc, Condvar, Mutex, MutexGuard},
   thread,
-  time::{Duration, Instant},
+  time::{Duration, SystemTime},
 };
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TimerError {
+  #[error("thread communication error {0}")]
+  ThreadCommunication(#[from] SendError<Option<Duration>>),
+}
+
+pub(crate) type Result<T> = std::result::Result<T, TimerError>;
 
 pub struct Timer {
   /** Restart/reset timer, if duration is not specified will continue using remaining duration */
   reset_sender: Sender<Option<Duration>>,
   /** Contains isRunning boolean mutex with Condvar for notifying when value changes */
   running_state: Arc<(Mutex<bool>, Condvar)>,
-  /// Crossbeam channel receiver that will receive "tick" events at a regular intervals
-  pub update_receiver: Receiver<Duration>,
 }
 
 impl Timer {
@@ -41,16 +50,18 @@ impl Timer {
   /// use std::time::Duration;
   /// use ticking_timer::Timer;
   ///
-  /// let timer = Timer::new(Duration::from_millis(100));
+  /// let timer = Timer::new(Duration::from_millis(100), |remaining| println!("{} seconds remaining", remaining.as_secs()));
   /// ```
   ///
   /// # Panics
   ///
   /// Panics if unable to spawn a separate thread for tracking time and emitting ticks.
-  pub fn new(update_frequency: Duration) -> Self {
+  pub fn new<F>(update_frequency: Duration, callback: F) -> Self
+  where
+    F: 'static + Fn(Duration) + Send + Sync,
+  {
     let running_state = Arc::new((Mutex::new(false), Condvar::new()));
     let (reset_sender, reset_receiver) = bounded::<Option<Duration>>(0);
-    let (update_sender, update_receiver) = bounded::<Duration>(0);
     let mut remaining = Duration::ZERO;
 
     thread::spawn({
@@ -61,23 +72,26 @@ impl Timer {
           let (lock, cvar) = &*running_state;
 
           while !remaining.is_zero() {
-            let now = Instant::now();
+            let now = SystemTime::now();
 
             let (is_running, _) = cvar
-              .wait_timeout(lock.lock().unwrap(), update_frequency)
-              .unwrap();
+              .wait_timeout(
+                lock.lock().expect("Unable to acquire a lock"),
+                update_frequency,
+              )
+              .expect("Failed to wait for timeout");
 
             if !*is_running {
               break;
             }
 
-            remaining = remaining.saturating_sub(now.elapsed());
-            update_sender.send(remaining).unwrap();
+            remaining = remaining.saturating_sub(now.elapsed().expect("Cannot get system time"));
+            callback(remaining);
           }
 
           if remaining.is_zero() {
             let (lock, _) = &*running_state;
-            *lock.lock().unwrap() = false;
+            *lock.lock().unwrap_or_else(|poison| poison.into_inner()) = false;
           }
         }
       }
@@ -86,25 +100,23 @@ impl Timer {
     Timer {
       reset_sender,
       running_state,
-      update_receiver,
     }
   }
 
   fn set_running_state(&self, new_state: bool) {
     let (lock, cvar) = &*self.running_state;
-    // TODO: Figure out how to return error here instead of unwrapping
-    let mut is_running = lock.lock().unwrap();
+    let mut is_running = lock.lock().unwrap_or_else(|poison| poison.into_inner());
     *is_running = new_state;
     cvar.notify_one();
   }
 
   /// Returns the is running state of this [`Timer`].
-  ///
-  /// # Panics
-  ///
-  /// Panics if unable to acquire a lock on running state
-  pub fn is_running(&self) -> bool {
-    *self.running_state.0.lock().unwrap()
+  pub fn is_running(&self) -> MutexGuard<bool> {
+    self
+      .running_state
+      .0
+      .lock()
+      .unwrap_or_else(|poison| poison.into_inner())
   }
 
   /// Pauses this [`Timer`]. Does nothing if [`Timer`] is already paused.
@@ -113,18 +125,21 @@ impl Timer {
   }
 
   /// Resumes this [`Timer`]. Does nothing if [`Timer`] is already running.
-  pub fn resume(&self) {
-    self.reset_sender.send(None).unwrap();
-    self.set_running_state(true)
+  pub fn resume(&self) -> Result<()> {
+    self.reset_sender.send(None)?;
+    self.set_running_state(true);
+    Ok(())
   }
 
   /// Switches running state of this [`Timer`] from running to paused and vice versa.
-  pub fn toggle(&self) {
-    if self.is_running() {
-      self.pause()
+  pub fn toggle(&self) -> Result<()> {
+    if *self.is_running() {
+      self.pause();
     } else {
-      self.resume()
+      self.resume()?;
     }
+
+    Ok(())
   }
 
   /// Pauses and resets this [`Timer`] to a new duration.
@@ -135,21 +150,22 @@ impl Timer {
   /// use std::time::Duration;
   /// use ticking_timer::Timer;
   ///
-  /// let timer = Timer::new(Duration::from_millis(100));
+  /// let timer = Timer::new(Duration::from_millis(100), |_| {});
   /// timer.reset(Duration::from_secs(1));
   /// timer.resume();
-  /// assert!(timer.is_running());
+  /// assert!(*timer.is_running());
   ///
   /// timer.reset(Duration::ZERO);
-  /// assert!(!timer.is_running());
+  /// assert!(!*timer.is_running());
   /// ```
   ///
   /// # Errors
   ///
   /// This function will return an error if unable to communicate with time-tracking thread.
-  pub fn reset(&self, new_duration: Duration) -> Result<(), SendError<Option<Duration>>> {
+  pub fn reset(&self, new_duration: Duration) -> Result<()> {
     self.pause();
-    self.reset_sender.send(Some(new_duration))
+    self.reset_sender.send(Some(new_duration))?;
+    Ok(())
   }
 }
 
@@ -163,71 +179,81 @@ impl Drop for Timer {
 #[cfg(test)]
 mod tests {
 
-  use crossbeam_channel::RecvTimeoutError;
+  use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread::sleep,
+  };
 
   use super::*;
 
   #[test]
   fn it_initializes_with_stopped_timer() {
-    let update_frequency = Duration::from_millis(1);
-    let timer = Timer::new(update_frequency);
-
-    assert!(!timer.is_running());
-    assert_eq!(
-      // Doubling timeout due to condvar.wait_timeout not being exact
-      timer.update_receiver.recv_timeout(update_frequency * 2),
-      Err(RecvTimeoutError::Timeout)
-    );
-  }
-
-  #[test]
-  fn it_runs_once_during_update_frequency() {
-    let update_frequency = Duration::from_millis(1);
-    let timer = Timer::new(update_frequency);
-
-    timer.reset(Duration::from_secs(1)).unwrap();
-    timer.resume();
-
-    assert!(timer.is_running());
-    assert!(timer
-      .update_receiver
-      // Doubling timeout due to condvar.wait_timeout not being exact
-      .recv_timeout(update_frequency * 2)
-      .is_ok());
-  }
-
-  #[test]
-  fn it_stops_when_time_has_ended() {
-    let update_frequency = Duration::from_millis(1);
-    let timer = Timer::new(update_frequency);
-
-    timer.reset(update_frequency).unwrap();
-    timer.resume();
-
-    timer.update_receiver.recv().unwrap();
-    timer.update_receiver.recv().unwrap();
-
-    assert!(!timer.is_running());
-  }
-
-  #[test]
-  fn it_pauses_timer() {
     let update_frequency = Duration::from_millis(100);
-    let timer = Timer::new(update_frequency);
+    let is_called = Arc::new(AtomicBool::new(false));
+    let timer = Timer::new(update_frequency, {
+      let is_called = is_called.clone();
+      move |_| is_called.store(true, Ordering::Relaxed)
+    });
 
-    timer.reset(update_frequency).unwrap();
-    timer.resume();
+    assert!(!*timer.is_running());
+
+    sleep(update_frequency * 2);
+
+    assert!(!is_called.load(Ordering::Relaxed));
+  }
+
+  #[test]
+  fn it_stops_when_time_has_ended() -> super::Result<()> {
+    let update_frequency = Duration::from_millis(100);
+    let timer = Timer::new(update_frequency, |_| {});
+
+    timer.reset(update_frequency)?;
+    timer.resume()?;
+
+    sleep(update_frequency * 2);
+
+    assert!(!*timer.is_running());
+
+    Ok(())
+  }
+
+  #[test]
+  fn it_pauses_timer() -> super::Result<()> {
+    let update_frequency = Duration::from_millis(100);
+    let timer = Timer::new(update_frequency, |_| {});
+
+    timer.reset(update_frequency)?;
+    timer.resume()?;
     timer.pause();
 
-    assert!(!timer.is_running());
+    assert!(!*timer.is_running());
+
+    Ok(())
   }
 
   #[test]
-  fn it_pauses_timer_on_reset() {
-    let timer = Timer::new(Duration::ZERO);
+  fn it_pauses_timer_on_reset() -> super::Result<()> {
+    let timer = Timer::new(Duration::ZERO, |_| {});
 
-    timer.reset(Duration::from_secs(1)).unwrap();
+    timer.reset(Duration::from_secs(1))?;
 
-    assert!(!timer.is_running());
+    assert!(!*timer.is_running());
+
+    Ok(())
+  }
+
+  #[test]
+  fn it_toggles_timer() -> super::Result<()> {
+    let timer = Timer::new(Duration::from_millis(100), |_| {});
+
+    timer.reset(Duration::from_secs(1))?;
+    timer.toggle()?;
+
+    assert!(*timer.is_running());
+
+    timer.toggle()?;
+    assert!(!*timer.is_running());
+
+    Ok(())
   }
 }


### PR DESCRIPTION
Reduces a number of threads needed to integrate it.

Also use SystemTime instead of Instant to keep accurate time after hibernation.